### PR TITLE
docs: fix simple typo, timestmap -> timestamp

### DIFF
--- a/API/api.py
+++ b/API/api.py
@@ -58,7 +58,7 @@ db = db_object.apiscan
 
 ############################# Start scan API ######################################
 def generate_hash():
-    # Return md5 hash value of current timestmap 
+    # Return md5 hash value of current timestamp 
     scanid = hashlib.md5(str(time.time())).hexdigest()
     return scanid
 


### PR DESCRIPTION
There is a small typo in API/api.py.

Should read `timestamp` rather than `timestmap`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md