### PR TITLE
fix: Add missing comma to `headers.py`

### DIFF
--- a/modules/headers.py
+++ b/modules/headers.py
@@ -32,8 +32,8 @@ request_headers = ['Accept',
 				   'User-Agent',
 				   'Upgrade',
 				   'Via',
-				   'Warning'
-				   'X-Requested-With'
+				   'Warning',
+				   'X-Requested-With',
 				   'X-Forwarded-For',
 				   'X-Forwarded-Host',
 				   'X-Forwarded-Proto',


### PR DESCRIPTION
* This comma has been most probably been left out unintentionally, leading to string concatenation between the two consecutive lines. This issue has been found automatically using a regular expression.